### PR TITLE
feat: AI query shortcut with >>> trigger

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -191,6 +191,15 @@ async def startup_event():
                     payload.get('supportGrounding', False)
                 )
                 await electron_client.send_response(data['id'], result)
+            elif data.get('action') == 'direct_query':
+                # Handle direct query without screenshot
+                logger.info("Processing direct_query action")
+                payload = data.get('payload', {})
+                query = payload.get('query', '')
+                
+                # Process the query with LLM (without screenshot)
+                result = await llm_service.process_direct_query(query)
+                await electron_client.send_response(data['id'], result)
             else:
                 logger.warning(f"Unknown action: {data.get('action')}")
                 if 'id' in data:

--- a/src/renderer/hooks/useDirectQuery.ts
+++ b/src/renderer/hooks/useDirectQuery.ts
@@ -1,0 +1,129 @@
+import { useCallback } from 'react';
+
+// Direct query trigger regex - >>> followed by query
+const directQueryRegex = /^\s*>>>(.+)$/;
+
+interface DirectQueryOptions {
+  onQueryStart?: () => void;
+  onQueryComplete?: (result: any) => void;
+  onQueryError?: (error: any) => void;
+}
+
+export const useDirectQuery = (options?: DirectQueryOptions) => {
+  const handleDirectQuery = useCallback(async (
+    query: string,
+    lineNumber: number,
+    editor: any
+  ) => {
+    if (!editor || !query) return;
+    
+    const model = editor.getModel();
+    if (!model) return;
+    
+    // Call onQueryStart if provided
+    options?.onQueryStart?.();
+    
+    try {
+      // Send query to backend API without screenshot
+      const result = await window.electronAPI.ai.sendCommand({
+        action: 'direct_query',
+        payload: {
+          query: query,
+          // No screenshot for >>> trigger
+        }
+      });
+      
+      // Replace the trigger line with the result
+      let responseText = '';
+      if (result.success && result.message) {
+        responseText = `\n${result.message}\n`;
+      } else {
+        responseText = '\n*[AI query failed]*\n';
+      }
+      
+      const range = {
+        startLineNumber: lineNumber,
+        startColumn: 1,
+        endLineNumber: lineNumber,
+        endColumn: model.getLineMaxColumn(lineNumber)
+      };
+      
+      editor.executeEdits('direct-query', [{
+        range,
+        text: responseText
+      }]);
+      
+      // Move cursor to after the inserted content
+      const nextLine = lineNumber + responseText.split('\n').length - 1;
+      editor.setPosition({ lineNumber: nextLine, column: 1 });
+      editor.revealLineInCenterIfOutsideViewport(nextLine);
+      
+      // Call onQueryComplete if provided
+      options?.onQueryComplete?.(result);
+      
+    } catch (error) {
+      console.error('Direct query failed:', error);
+      
+      // Replace with error message
+      const range = {
+        startLineNumber: lineNumber,
+        startColumn: 1,
+        endLineNumber: lineNumber,
+        endColumn: model.getLineMaxColumn(lineNumber)
+      };
+      
+      editor.executeEdits('direct-query-error', [{
+        range,
+        text: `\n*[Query failed: ${error}]*\n`
+      }]);
+      
+      // Call onQueryError if provided
+      options?.onQueryError?.(error);
+    }
+  }, [options]);
+
+  const checkForDirectQuery = useCallback((
+    editor: any,
+    changes: any
+  ): boolean => {
+    // Check if Enter key was pressed
+    const hasEnter = changes.some((change: any) => 
+      change.text.includes('\n')
+    );
+    
+    if (!hasEnter) return false;
+    
+    const position = editor.getPosition();
+    if (!position) return false;
+    
+    const model = editor.getModel();
+    if (!model) return false;
+    
+    // Check the previous line (before the new line)
+    const previousLineNumber = position.lineNumber - 1;
+    if (previousLineNumber < 1) return false;
+    
+    const previousLineContent = model.getLineContent(previousLineNumber);
+    
+    // Check for >>> direct query trigger
+    const directQueryMatch = previousLineContent.match(directQueryRegex);
+    if (directQueryMatch) {
+      const query = directQueryMatch[1] ? directQueryMatch[1].trim() : '';
+      console.log('Direct query detected:', { line: previousLineNumber, query });
+      
+      if (query.length > 0) {
+        // Execute direct query without opening AI window
+        handleDirectQuery(query, previousLineNumber, editor);
+        return true; // Query was handled
+      }
+    }
+    
+    return false; // No query found
+  }, [handleDirectQuery]);
+
+  return {
+    checkForDirectQuery,
+    handleDirectQuery,
+    directQueryRegex
+  };
+};

--- a/src/renderer/pages/RecordingPage.tsx
+++ b/src/renderer/pages/RecordingPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import { useRecordingStore } from '../store/recordingStore';
+import { useDirectQuery } from '../hooks/useDirectQuery';
 
 interface RecordingPageProps {
   onRecordingComplete: (sessionId: string) => void;
@@ -19,7 +20,10 @@ export const RecordingPage: React.FC<RecordingPageProps> = ({ onRecordingComplet
   const sessionIdRef = useRef<string | null>(null);
   const recordingStartTimeRef = useRef<number>(0);
   
-  const { addNote, clearNotes, audioDevices, setAudioDevices, selectedMic, selectedSystem, setSelectedMic, setSelectedSystem, setRecordingDuration } = useRecordingStore();
+  const { addNote, clearNotes, selectedMic, selectedSystem, setSelectedMic, setSelectedSystem, setRecordingDuration } = useRecordingStore();
+  
+  // Use direct query hook
+  const { checkForDirectQuery } = useDirectQuery();
 
   // --- Heading timestamp (non-intrusive) ---
   const headingLineRegex = /^#{1,6}\s+/; // H1~H6
@@ -339,8 +343,10 @@ export const RecordingPage: React.FC<RecordingPageProps> = ({ onRecordingComplet
     updateHeadingWidgets();
     // Initialize prev keys so only new headings get timestamps while recording
     try { updateHeadingTimestamps(notes || ''); } catch {}
-    editor.onDidChangeModelContent(() => {
+    editor.onDidChangeModelContent((e: any) => {
       updateHeadingTimestamps(editor.getValue());
+      // Check for direct query trigger on Enter
+      checkForDirectQuery(editor, e.changes);
     });
   };
 


### PR DESCRIPTION
## Summary
- Implement AI query shortcut using `>>>` trigger in Monaco editors
- Direct query processing without screenshot capture
- Backend integration with OpenAI Responses API and web search support

## Changes
### Frontend
- Added `>>>` trigger detection in Monaco editors (FloatingWindow and RecordingPage)
- Created reusable `useDirectQuery` hook for consistent behavior
- Disabled screenshot capture for `>>>` queries as requested
- Fixed TypeScript warnings in RecordingPage

### Backend
- Added `direct_query` action handler in main.py
- Implemented `process_direct_query` method in LLM service
- Added support for OpenAI Responses API with web search tools
- Fallback to Chat Completions API with function calling
- Proper tool call detection and handling

## Features
- Type `>>>your question` and press Enter in any Monaco markdown editor
- AI processes the query directly without capturing screenshots
- Web search capability detection (when available)
- Graceful fallback between API versions
- Response inserted directly in editor, replacing the trigger line

## Testing
- Build successful with no compilation errors
- Merged latest changes from main branch
- Ready for E2E testing with new Playwright setup

🤖 Generated with [Claude Code](https://claude.ai/code)