### PR TITLE
Fix GitHub build failure for v0.0.2 by adding PortAudio dependency

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -66,6 +66,12 @@ jobs:
       shell: powershell
       if: matrix.os == 'windows-latest'
     
+    - name: Install system dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y portaudio19-dev
+    
     - name: Install Node dependencies
       run: npm ci
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
       shell: powershell
       if: matrix.os == 'windows-latest'
     
+    - name: Install system dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y portaudio19-dev
+    
     - name: Install Node dependencies
       run: npm ci
     


### PR DESCRIPTION
## Summary
- Fixed the GitHub Actions build failure that occurred in v0.0.2 release
- Added missing PortAudio system dependency for Ubuntu builds

## Problem
The v0.0.2 release build failed on Ubuntu because PyAudio requires the PortAudio library headers during compilation. The error was:
```
src/pyaudio/device_api.c:9:10: fatal error: portaudio.h: No such file or directory
```

## Solution
Added `portaudio19-dev` system dependency installation step for Ubuntu in both:
- `.github/workflows/release.yml` - Main release workflow triggered by version tags
- `.github/workflows/manual-release.yml` - Manual release workflow for testing

The test workflow (`.github/workflows/test.yml`) already had this dependency configured correctly.

## Testing
Once this PR is merged, the next release build should successfully compile PyAudio on Ubuntu and complete the release process for all platforms (macOS, Ubuntu, Windows).