### PR TITLE
Fix GitHub build failure for v0.0.3 by adding PortAudio dependency for macOS

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -72,6 +72,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y portaudio19-dev
     
+    - name: Install system dependencies (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install portaudio
+    
     - name: Install Node dependencies
       run: npm ci
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y portaudio19-dev
     
+    - name: Install system dependencies (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install portaudio
+    
     - name: Install Node dependencies
       run: npm ci
     


### PR DESCRIPTION
## Summary
- Fixed the GitHub Actions build failure that occurred in v0.0.3 release on macOS
- Added missing PortAudio system dependency for macOS builds

## Problem
The v0.0.3 release build failed on macOS because PyAudio requires the PortAudio library headers during compilation. The error was:
```
src/pyaudio/device_api.c:9:10: fatal error: 'portaudio.h' file not found
```

## Solution
Added `brew install portaudio` system dependency installation step for macOS in both:
- `.github/workflows/release.yml` - Main release workflow triggered by version tags
- `.github/workflows/manual-release.yml` - Manual release workflow for testing

This complements the previous fix that added PortAudio for Ubuntu builds.

## Testing
Once this PR is merged, the next release build should successfully compile PyAudio on all platforms (macOS, Ubuntu, Windows), completing the release process without failures.