### PR TITLE
fix: remove macOS ZIP file pattern from manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -108,9 +108,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: mac-release
-        path: |
-          release/*.dmg
-          release/*.zip
+        path: release/*.dmg
         if-no-files-found: error
     
     - name: Upload Linux artifacts
@@ -150,7 +148,6 @@ jobs:
         echo "" >> release-notes.md
         echo "### macOS" >> release-notes.md
         echo "- **DMG**: For standard installation" >> release-notes.md
-        echo "- **ZIP**: For portable use" >> release-notes.md
         echo "" >> release-notes.md
         echo "### Windows" >> release-notes.md
         echo "- **EXE**: NSIS installer for Windows" >> release-notes.md
@@ -185,7 +182,6 @@ jobs:
         prerelease: ${{ github.event.inputs.prerelease }}
         files: |
           release-artifacts/mac-release/*.dmg
-          release-artifacts/mac-release/*.zip
           release-artifacts/linux-release/*.AppImage
           release-artifacts/windows-release/*.exe
         fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary
Fixes GitHub Actions failure in manual release workflow by removing ZIP file patterns that don't exist.

The manual release workflow was expecting both DMG and ZIP files for macOS builds, but only DMG files are actually generated. This caused the release step to fail with:
```
⚠️ Pattern 'release-artifacts/mac-release/*.zip' does not match any files.
```

## Changes
- Remove ZIP file from macOS artifact upload path
- Remove ZIP file pattern from release files list  
- Update release notes to only mention DMG for macOS installation

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test manual release workflow runs without ZIP file errors
- [ ] Confirm DMG files are still uploaded correctly

Fixes the failure seen in: https://github.com/ntubiolin/Screen2Action/actions/runs/17286686344/job/49065277283

🤖 Generated with [Claude Code](https://claude.ai/code)