### PR TITLE
docs: Add BlackHole Multi-Output Device configuration link for macOS audio setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Edit `backend/config/mcp_servers.json` to add custom MCP servers:
 For capturing system audio, install BlackHole:
 1. Download from: https://github.com/ExistentialAudio/BlackHole
 2. Configure Multi-Output Device in Audio MIDI Setup
+   - Detailed setup guide: [BlackHole Multi-Output Device Configuration](https://github.com/ExistentialAudio/BlackHole/wiki/Multi-Output-Device#4-select-output-devices)
 3. The app will automatically detect and use BlackHole for system audio
 
 ### Note Timestamps


### PR DESCRIPTION
## Summary
Added a detailed configuration link to the BlackHole Multi-Output Device setup guide in the README.md file.

## Changes
- Added link to BlackHole wiki with step-by-step instructions for configuring system audio capture on macOS
- Enhanced the Audio Recording Setup section with more detailed guidance
- Improves user experience for setting up audio recording capabilities

## Link Added
https://github.com/ExistentialAudio/BlackHole/wiki/Multi-Output-Device\#4-select-output-devices

This link provides comprehensive instructions on how to configure the Multi-Output Device on macOS to capture system speaker output, which is essential for proper audio recording functionality in Screen2Action.

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified link is accessible and contains relevant information
- [x] Confirmed placement in README is logical and helpful for users